### PR TITLE
Enable optimizer with yul workaround

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -49,7 +49,18 @@ const accounts: HDAccountsUserConfig = {
 // Go to https://hardhat.org/config/ to learn more
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.4",
+  solidity: {
+    version: "0.8.4",
+    settings: {
+      optimizer: {
+	enabled: true,
+	runs: 1000,
+	details: {
+          yul: false
+        }
+      },
+    },
+  },
   networks: {
     mainnet: {
       url: fornoURLs[ICeloNetwork.MAINNET],


### PR DESCRIPTION
farm-bot now compiles without a warning about bytecode size