### PR TITLE
chore: updated farm bot pragma

### DIFF
--- a/contracts/farm-bot.sol
+++ b/contracts/farm-bot.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >=0.5.0 <0.9.0;
+pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
 


### PR DESCRIPTION
seems worthwhile using the latest and greatest

also I read that SafeMath is no longer necessary with ^0.8.0 because it handles integer overflow better