### PR TITLE
fix: minAmountsOut type

### DIFF
--- a/contracts/UbeswapFarmBot.sol
+++ b/contracts/UbeswapFarmBot.sol
@@ -302,7 +302,7 @@ contract UbeswapFarmBot is ERC20, AccessControl {
         uint256[] memory _compounderFee,
         uint256[] memory _reserveFee,
         address[][2][] memory _paths,
-        uint256[][2] memory _minAmountsOut,
+        uint256[2][] memory _minAmountsOut,
         uint256 _deadline
     ) private {
         uint256 _totalAmountToken0 = 0;
@@ -370,7 +370,7 @@ contract UbeswapFarmBot is ERC20, AccessControl {
      */
     function compound(
         address[][2][] memory _paths,
-        uint256[][2] memory _minAmountsOut,
+        uint256[2][] memory _minAmountsOut,
         uint256 _deadline
     ) public ensure(_deadline) onlyRole(COMPOUNDER_ROLE) {
         require(


### PR DESCRIPTION
From the docs:

> In Solidity, X[3] is always an array containing three elements of type X, even if X is itself an array.

So for minAmountsOut to be an array of length-2 arrays, it needs to be uint256[2][]

https://docs.soliditylang.org/en/v0.8.11/types.html#arrays