### PR TITLE
refactor: simplify fees

### DIFF
--- a/contracts/IRevoFees.sol
+++ b/contracts/IRevoFees.sol
@@ -9,20 +9,20 @@ struct TokenAmount {
 }
 
 interface IRevoFees {
-    function compounderFee(TokenAmount[] calldata interestAccrued)
+    function compounderFee(uint256 _interestAccrued)
+        external
+        view
+        returns (uint256);
+
+    function compounderBonus(TokenAmount calldata interestAccrued)
         external
         view
         returns (TokenAmount[] memory);
 
-    function compounderBonus(TokenAmount[] calldata interestAccrued)
+    function reserveFee(uint256 _interestAccrued)
         external
         view
-        returns (TokenAmount[] memory);
-
-    function reserveFee(TokenAmount[] calldata interestAccrued)
-        external
-        view
-        returns (TokenAmount[] memory);
+        returns (uint256);
 
     function withdrawalFee(
         uint256 interestEarnedNumerator,

--- a/contracts/RevoFees.sol
+++ b/contracts/RevoFees.sol
@@ -40,20 +40,7 @@ contract RevoFees is Owned, IRevoFees {
         reserveFeeDenominator = _reserveFeeDenominator;
     }
 
-    function calculateFee(
-        TokenAmount[] memory _interestAccrued,
-        uint256 _feeNumerator,
-        uint256 _feeDenominator
-    ) private pure returns (TokenAmount[] memory output) {
-        output = new TokenAmount[](_interestAccrued.length);
-        for (uint256 idx = 0; idx < _interestAccrued.length; idx++) {
-            uint256 _fee = (_interestAccrued[idx].amount * _feeNumerator) /
-                _feeDenominator;
-            output[idx] = TokenAmount(_interestAccrued[idx].token, _fee);
-        }
-    }
-
-    function compounderBonus(TokenAmount[] memory _interestAccrued)
+    function compounderBonus(TokenAmount memory _interestAccrued)
         external
         pure
         override
@@ -62,30 +49,24 @@ contract RevoFees is Owned, IRevoFees {
         return new TokenAmount[](0); // intentionally returns empty list
     }
 
-    function compounderFee(TokenAmount[] memory _interestAccrued)
+    function compounderFee(uint256 _interestAccrued)
         external
         view
         override
-        returns (TokenAmount[] memory output)
+        returns (uint256)
     {
-        output = calculateFee(
-            _interestAccrued,
-            compounderFeeNumerator,
-            compounderFeeDenominator
-        );
+        return
+            (_interestAccrued * compounderFeeNumerator) /
+            compounderFeeDenominator;
     }
 
-    function reserveFee(TokenAmount[] memory _interestAccrued)
+    function reserveFee(uint256 _interestAccrued)
         external
         view
         override
-        returns (TokenAmount[] memory output)
+        returns (uint256)
     {
-        output = calculateFee(
-            _interestAccrued,
-            reserveFeeNumerator,
-            reserveFeeDenominator
-        );
+        return (_interestAccrued * reserveFeeNumerator) / reserveFeeDenominator;
     }
 
     function issueCompounderBonus(address recipient) external pure override {

--- a/contracts/mocks/MockRevoFees.sol
+++ b/contracts/mocks/MockRevoFees.sol
@@ -5,24 +5,25 @@ import "../IRevoFees.sol";
 contract MockRevoFees is IRevoFees {
     TokenAmount[] bonuses;
 
-    function addBonus(TokenAmount memory _tokenAmount) external {
-        bonuses.push(_tokenAmount);
+    uint256 compounderFeeAmount;
+    function setCompounderFee(uint256 _compounderFee) external {
+        compounderFeeAmount = _compounderFee;
     }
 
-    function removeBonus() external {
-        bonuses.pop();
+    function compounderFee(uint256 _interestAccrued) external override view returns (uint256) {
+        return compounderFeeAmount;
     }
 
-    function compounderFee(TokenAmount[] calldata interestAccrued) external override view returns (TokenAmount[] memory) {
-        return bonuses;
-    }
-
-    function compounderBonus(TokenAmount[] calldata interestAccrued) external override view returns (TokenAmount[] memory) {
+    function compounderBonus(TokenAmount memory _interestAccrued) external override view returns (TokenAmount[] memory) {
         return new TokenAmount[](0);
     }
 
-    function reserveFee(TokenAmount[] calldata interestAccrued) external override view returns (TokenAmount[] memory) {
-        return bonuses;
+    uint256 reserveFeeAmount;
+    function setReserveFee(uint256 _reserveFee) external {
+        reserveFeeAmount = _reserveFee;
+    }
+    function reserveFee(uint256 _interestAccrued) external override view returns (uint256) {
+        return reserveFeeAmount;
     }
 
     uint256 withdrawalFeeNumerator = 25;


### PR DESCRIPTION
I caused some serious pain by implementing fees in units of rewards tokens, rather than LP tokens. This increases the gas costs of calling `compound` and adds complexity to `compound`.

Switching to LPs for rewards shifts complexity away from users' critical path, at the cost of compounders having a bit more difficult time figuring out how much calling `compound` will be worth to them (since they'll need to check the amount of rewards tokens earned by farm bot, and then estimate the LPs they can buy for the latent rewards). 

I removed the helpers for estimating a `compound` payout, since they can be computed by the client (as long as they have access to the staking rewards contract, the fees contract, and the farm bot contract), and TBH because it's late and I needed to punt something. If we decide we want them to be back in a smart contract later, we can easily add a wrapper for it, so I think it's actually ok to omit for now.