### PR TITLE
Make pausable, remove approvals from critical paths, add setter for router address

### DIFF
--- a/contracts/openzeppelin-solidity/contracts/Pausable.sol
+++ b/contracts/openzeppelin-solidity/contracts/Pausable.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (security/Pausable.sol)
+
+pragma solidity ^0.8.0;
+
+import "./Context.sol";
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+abstract contract Pausable is Context {
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    bool private _paused;
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    constructor() {
+        _paused = false;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view virtual returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        require(!paused(), "Pausable: paused");
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        require(paused(), "Pausable: not paused");
+        _;
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+}


### PR DESCRIPTION
A couple of changes here.

1. Pre-approve all necessary transfers for minting/staking LP and swapping rewards. This removes approvals from the critical path, prevents any potential bugs with approvals, and is [precisely what Beefy does](https://github.com/beefyfinance/beefy-contracts/blob/c72a577eaa446088cd598c219e55ee5f95e966a1/contracts/BIFI/strategies/Cometh/StrategyMultiRewardsPolygonLP.sol#L202).
2. Make the contract Pausable. This comes basically for free with the `_giveAllowances` and `_removeAllowances` helpers, and is generally a good quality of life improvement.
3. Add a setter for the router address. This one is unrelated; sorry for clumping it into this PR!