### PR TITLE
fix: avoid safeApprove

### DIFF
--- a/contracts/UbeswapFarmBot.sol
+++ b/contracts/UbeswapFarmBot.sol
@@ -262,7 +262,7 @@ contract UbeswapFarmBot is ERC20, AccessControl, Pausable {
         uint256 _deadline
     ) private returns (uint256) {
         if (_swapPath.length >= 2 && _startTokenBudget > 0) {
-            _startToken.safeApprove(address(router), _startTokenBudget);
+            _startToken.safeIncreaseAllowance(address(router), _startTokenBudget);
             uint256[] memory _swapResultAmounts = router
                 .swapExactTokensForTokens(
                     _startTokenBudget,
@@ -304,8 +304,8 @@ contract UbeswapFarmBot is ERC20, AccessControl, Pausable {
         }
 
         // Approve the router to spend the bot's token0/token1
-        stakingToken0.safeApprove(address(router), _totalAmountToken0);
-        stakingToken1.safeApprove(address(router), _totalAmountToken1);
+        stakingToken0.approve(address(router), _totalAmountToken0);
+        stakingToken1.approve(address(router), _totalAmountToken1);
 
         // Actually add liquidity
         router.addLiquidity(


### PR DESCRIPTION
it's deprecated, and fails when setting to something nonzero after an initial approval

I changed it to safeIncreaseAllowance in the place we are guaranteed to spend the increased allowance straight after. but in the place where we then deposit into a liquidity pool that could lead to an unspent allowance, so I used a regular `approve` there. The other option would be to set the approval to 0 right after depositing into a liquidity pool, but I think that's over-doing it. Competing products (Beefy, looking at you) approve the router for infinite amounts to save gas.