### PR TITLE
feat(ubeswap): Add in Ubeswap single reward farm support

### DIFF
--- a/contracts/farms/RevoUbeswapSingleRewardFarmBot.sol
+++ b/contracts/farms/RevoUbeswapSingleRewardFarmBot.sol
@@ -31,17 +31,22 @@ contract RevoUbeswapSingleRewardFarmBot is RevoUniswapStakingTokenStrategy {
         address _swapRouter,
         address _liquidityRouter,
         string memory _symbol
-    ) 	RevoUniswapStakingTokenStrategy(
+    )
+        RevoUniswapStakingTokenStrategy(
             _owner,
             _reserveAddress,
             _stakingToken,
             _revoFees,
-	    _rewardsTokens,
+            _rewardsTokens,
             _swapRouter,
             _liquidityRouter,
             _symbol
-        ) {
-	require (_rewardsTokens.length == 1, "Must specify exactly one rewards token");
+        )
+    {
+        require(
+            _rewardsTokens.length == 1,
+            "Must specify exactly one rewards token"
+        );
         stakingRewards = IStakingRewards(_stakingRewards);
     }
 

--- a/contracts/farms/RevoUbeswapSingleRewardFarmBot.sol
+++ b/contracts/farms/RevoUbeswapSingleRewardFarmBot.sol
@@ -1,0 +1,61 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+import "hardhat/console.sol";
+
+import "../ubeswap-farming/interfaces/IStakingRewards.sol";
+import "./common/RevoUniswapStakingTokenStrategy.sol";
+import "../openzeppelin-solidity/contracts/SafeERC20.sol";
+
+/**
+ * RevoUbeswapSingleRewardFarmBot is a farmbot:
+ *   * that runs on top of an IStakingRewards farm
+ *   * whose stakingToken is an IUniswapV2Pair ("LP")
+ *   * that acquires LP constintuent tokens through swaps on an IUniswapV2Router02
+ *   * that mints LP from constituent tokens through an IUniswapV2Router02
+ *
+ * This farmbot is suitable for use on top of Ubeswap farms that have a single reward token.
+ **/
+contract RevoUbeswapSingleRewardFarmBot is RevoUniswapStakingTokenStrategy {
+    using SafeERC20 for IERC20;
+
+    IStakingRewards public stakingRewards;
+
+    constructor(
+        address _owner,
+        address _reserveAddress,
+        address _stakingRewards,
+        address _stakingToken,
+        address _revoFees,
+        address[] memory _rewardsTokens,
+        address _swapRouter,
+        address _liquidityRouter,
+        string memory _symbol
+    ) 	RevoUniswapStakingTokenStrategy(
+            _owner,
+            _reserveAddress,
+            _stakingToken,
+            _revoFees,
+	    _rewardsTokens,
+            _swapRouter,
+            _liquidityRouter,
+            _symbol
+        ) {
+	require (_rewardsTokens.length == 1, "Must specify exactly one rewards token");
+        stakingRewards = IStakingRewards(_stakingRewards);
+    }
+
+    function _deposit(uint256 _lpAmount) internal override whenNotPaused {
+        require(_lpAmount > 0, "Cannot invest in farm because lpAmount is 0");
+        stakingToken.safeIncreaseAllowance(address(stakingRewards), _lpAmount);
+        stakingRewards.stake(_lpAmount);
+    }
+
+    function _withdraw(uint256 _lpAmount) internal override {
+        stakingRewards.withdraw(_lpAmount);
+    }
+
+    function _claimRewards() internal override whenNotPaused {
+        stakingRewards.getReward();
+    }
+}

--- a/contracts/mocks/MockStakingRewards.sol
+++ b/contracts/mocks/MockStakingRewards.sol
@@ -1,0 +1,85 @@
+pragma solidity ^0.8.0;
+
+import "../openzeppelin-solidity/contracts/IERC20.sol";
+import "../ubeswap-farming/interfaces/IMoolaStakingRewards.sol";
+
+contract MockStakingRewards is IStakingRewards {
+    IERC20 public rewardsToken;
+
+    IERC20 public stakingToken;
+
+    constructor(
+        address _rewardsToken,
+        address _stakingToken
+    ) {
+        rewardsToken = IERC20(_rewardsToken);
+        stakingToken = IERC20(_stakingToken);
+    }
+
+    // Views
+    function lastTimeRewardApplicable() external override view returns (uint256) {
+        // farm bot shouldn't need this
+        require(false);
+        return 0;
+    }
+
+    function rewardPerToken() external override view returns (uint256) {
+        // farm bot shouldn't need this
+        require(false);
+        return 0;
+    }
+
+    uint256 public amountEarned;
+    function setAmountEarned(uint256 _amountEarned) public {
+        amountEarned = _amountEarned;
+    }
+    function earned(address account) external override view returns (uint256) {
+        return amountEarned;
+    }
+
+    function getRewardForDuration() external override view returns (uint256) {
+        // farm bot shouldn't need this
+        require(false);
+        return 0;
+    }
+
+    function totalSupply() external override view returns (uint256) {
+        // farm bot shouldn't need this
+        require(false);
+        return 0;
+    }
+
+    uint256 public accountBalance;
+    function setAccountBalance(uint256 _accountBalance) external {
+        accountBalance = _accountBalance;
+    }
+    function balanceOf(address account) external override view returns (uint256) {
+        return accountBalance;
+    }
+
+    // Mutative
+    mapping(address => uint) public staked;
+    function stake(uint256 amount) external override {
+        staked[msg.sender] += amount;
+        stakingToken.transferFrom(msg.sender, address(this), amount);
+    }
+
+    function withdraw(uint256 amount) external override {
+        require(staked[msg.sender] >= amount);
+        staked[msg.sender] -= amount;
+        stakingToken.transfer(msg.sender, amount);
+	this.getReward();
+    }
+
+    function getReward() external override {
+        rewardsToken.transfer(msg.sender, amountEarned);
+	for (uint i=0; i<externalRewardsTokens.length; i++) {
+	    externalRewardsTokens[i].transfer(msg.sender, amountEarnedExternal[i]);
+	}
+    }
+
+    function exit() external override {
+        // farm bot shouldn't need this
+        require(false);
+    }
+}

--- a/contracts/mocks/MockStakingRewards.sol
+++ b/contracts/mocks/MockStakingRewards.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.8.0;
 
 import "../openzeppelin-solidity/contracts/IERC20.sol";
-import "../ubeswap-farming/interfaces/IMoolaStakingRewards.sol";
+import "../ubeswap-farming/interfaces/IStakingRewards.sol";
 
 contract MockStakingRewards is IStakingRewards {
     IERC20 public rewardsToken;
@@ -73,9 +73,6 @@ contract MockStakingRewards is IStakingRewards {
 
     function getReward() external override {
         rewardsToken.transfer(msg.sender, amountEarned);
-	for (uint i=0; i<externalRewardsTokens.length; i++) {
-	    externalRewardsTokens[i].transfer(msg.sender, amountEarnedExternal[i]);
-	}
     }
 
     function exit() external override {

--- a/deploy/05-ube-celo-farm/index.ts
+++ b/deploy/05-ube-celo-farm/index.ts
@@ -1,0 +1,41 @@
+import { DeployerFn } from "@ubeswap/hardhat-celo"
+import { RevoUbeswapSingleRewardFarmBot__factory } from "../../typechain"
+
+const main: DeployerFn<{}> = async ({
+  deployCreate2,
+  deployer,
+}) => {
+  const OWNER_ADDRESS = "0x642abB1237009956BB67d0B174337D76F0455EDd" // Temporary owner, should change to multi-sig
+  const RESERVE_ADDRESS = "0x99649aF776ff1b024F12e8Fe9dfA59A6c0b4bD9C" // Multi-sig owner
+  const STAKING_REWARDS_ADDRESS = "0x295D6f96081fEB1569d9Ce005F7f2710042ec6a1" // StakingRewards address
+  const STAKING_TOKEN_ADDRESS = "0xe7B5AD135fa22678F426A381C7748f6A5f2c9E6C" // UBE-CELO LP address
+  const REVO_FEES_ADDRESS = "0x3b9ffc0ebb0164daf0c94f88df29a6e46e984d12" // RevoFees address
+  const SWAP_ROUTER_ADDRESS = "0x7D28570135A2B1930F331c507F65039D4937f66c" // UbeswapMoolaRouter address
+  const LIQUIDITY_ROUTER_ADDRESS = "0xe3d8bd6aed4f159bc8000a9cd47cffdb95f96121" // UniswapV2Router02 address
+  const REWARDS_TOKENS = [
+    "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec", // UBE
+  ]
+  const SYMBOL = "RFP" // "Revo Farm Point". Same convention as Ubeswap's "ULP".
+
+  const revoUbeswapSingleRewardFarmBot = await deployCreate2('RevoUbeswapSingleRewardFarmBot', {
+    factory: RevoUbeswapSingleRewardFarmBot__factory,
+    signer: deployer,
+    args: [
+      OWNER_ADDRESS,
+      RESERVE_ADDRESS,
+      STAKING_REWARDS_ADDRESS,
+      STAKING_TOKEN_ADDRESS,
+      REVO_FEES_ADDRESS,
+      REWARDS_TOKENS,
+      SWAP_ROUTER_ADDRESS,
+      LIQUIDITY_ROUTER_ADDRESS,
+      SYMBOL
+    ]
+  })
+
+  return {
+    RevoUbeswapSingleRewardFarmBot: revoUbeswapSingleRewardFarmBot.address,
+  }
+}
+
+export default main

--- a/deploy/06-configure-ube-celo/index.ts
+++ b/deploy/06-configure-ube-celo/index.ts
@@ -1,0 +1,51 @@
+import { DeployerFn } from "@ubeswap/hardhat-celo"
+import { RevoUbeswapSingleRewardFarmBot__factory, ERC20__factory } from "../../typechain"
+import { ContractTransaction } from "ethers"
+import { ethers } from "ethers"
+
+export const doTx = async (
+  action: string,
+  tx: Promise<ContractTransaction>
+): Promise<void> => {
+  console.log(`Performing ${action}...`);
+  const result = await (await tx).wait();
+  console.log(`${action} done at tx ${result.transactionHash}`);
+};
+
+const main: DeployerFn<{}> = async ({
+  deployer,
+}) => {
+
+  const FARM_ADDRESS = "0xa2487190fCE90B2462102656478BA6Ad7F548F88"
+
+  const COMPOUNDER_ADDRESS = "0x642abB1237009956BB67d0B174337D76F0455EDd"
+  const COMPOUNDER_ROLE = await RevoUbeswapSingleRewardFarmBot__factory.connect(FARM_ADDRESS, deployer).COMPOUNDER_ROLE()
+
+  await doTx(
+    "Setting compounder role",
+    RevoUbeswapSingleRewardFarmBot__factory.connect(FARM_ADDRESS, deployer).grantRole(
+      COMPOUNDER_ROLE,
+      COMPOUNDER_ADDRESS
+    )
+  )
+
+  await doTx(
+    'Update slippage',
+    RevoUbeswapSingleRewardFarmBot__factory.connect(FARM_ADDRESS, deployer).updateSlippage(95, 100)
+  )
+
+  const STAKING_TOKEN_ADDRESS = "0xe7B5AD135fa22678F426A381C7748f6A5f2c9E6C" // UBE-CELO LP address
+
+  const lpBalance = await ERC20__factory.connect(STAKING_TOKEN_ADDRESS, deployer).balanceOf(COMPOUNDER_ADDRESS)
+
+  if (lpBalance.gt(ethers.BigNumber.from(0))) {
+    // Approve farm to spend it
+    await ERC20__factory.connect(STAKING_TOKEN_ADDRESS, deployer).approve(FARM_ADDRESS, lpBalance)
+    // Deposit LP
+    await (await RevoUbeswapSingleRewardFarmBot__factory.connect(FARM_ADDRESS, deployer).deposit(lpBalance)).wait()
+  }
+
+  return {}
+}
+
+export default main

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -15,12 +15,16 @@
 
 import revoFeeDeployer from './01-revo-fees/index'
 import mcUSDmcEURFarmDeployer from './02-mcusd-mceur-farm/index'
+import ubeCeloFarmDeployer from './05-ube-celo-farm/index'
+import ubeCeloFarmConfigure from './06-configure-ube-celo/index'
 import configureFarm from './03-configure-farm/index'
 import addLiquidity from './04-add-liquidity/index'
 
 export default {
   'revo-fees': revoFeeDeployer,
   'mcusd-mceur': mcUSDmcEURFarmDeployer,
+  'ube-celo': ubeCeloFarmDeployer,
+  'configure-ube-celo': ubeCeloFarmConfigure,
   'configure-farm': configureFarm,
   'add-liquidity': addLiquidity
 }

--- a/deployments/ube-celo.mainnet.addresses.json
+++ b/deployments/ube-celo.mainnet.addresses.json
@@ -1,0 +1,3 @@
+{
+  "RevoUbeswapSingleRewardFarmBot": "0xa2487190fCE90B2462102656478BA6Ad7F548F88"
+}

--- a/test/RevoUbeswapSingleRewardFarmBot.test.ts
+++ b/test/RevoUbeswapSingleRewardFarmBot.test.ts
@@ -1,0 +1,408 @@
+import {expect} from "chai"
+import * as chai from 'chai'
+import chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised)
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
+import {BigNumber} from "ethers";
+import {
+  RevoUbeswapSingleRewardFarmBot,
+  MockERC20,
+  MockLPToken,
+  MockRevoFees,
+  MockRouter,
+  MockStakingRewards,
+  RevoUbeswapSingleRewardFarmBot__factory
+} from "../typechain"
+
+const {ethers} = require("hardhat")
+
+
+describe('RevoUbeswapSingleRewardFarmBot tests', () => {
+  let deployer: SignerWithAddress, reserve: SignerWithAddress, compounder: SignerWithAddress, investor0: SignerWithAddress, investor1: SignerWithAddress,
+    feeContract: MockRevoFees,
+    token0Contract: MockERC20, token1Contract: MockERC20,
+    rewardsToken0Contract: MockERC20,
+    lpTokenContract: MockLPToken,
+    stakingRewardsContract: MockStakingRewards,
+    routerContract: MockRouter,
+    stakingToken0Address: string, stakingToken1Address: string,
+    ubeswapSingleRewardFarmBotFactory: RevoUbeswapSingleRewardFarmBot__factory
+
+  beforeEach(async () => {
+    [deployer, reserve, compounder, investor0, investor1] = await ethers.getSigners()
+    const revoBountyFactory = await ethers.getContractFactory('MockRevoFees')
+    feeContract = await revoBountyFactory.deploy()
+
+    const erc20Factory = await ethers.getContractFactory('MockERC20')
+
+    rewardsToken0Contract = await erc20Factory.deploy('Mock rewards token 0', 'RWD0')
+
+    token0Contract = await erc20Factory.deploy('Mock token 0', 'T0')
+    token1Contract = await erc20Factory.deploy('Mock token 1', 'T1')
+
+    const lpFactory = await ethers.getContractFactory('MockLPToken')
+    lpTokenContract = await lpFactory.deploy(
+      'Mock staking token', // name
+      'LP', // symbol
+      token0Contract.address,
+      token1Contract.address
+    )
+
+    const stakingRewardsFactory = await ethers.getContractFactory('MockStakingRewards')
+    stakingRewardsContract = await stakingRewardsFactory.deploy(
+      rewardsToken0Contract.address, // rewards token
+      lpTokenContract.address
+    )
+
+    const routerFactory = await ethers.getContractFactory('MockRouter')
+    routerContract = await routerFactory.deploy()
+    await routerContract.setLPToken(lpTokenContract.address);
+
+    // sanity check mock LP contract
+    stakingToken0Address = await lpTokenContract.token0()
+    expect(stakingToken0Address).to.equal(token0Contract.address)
+    stakingToken1Address = await lpTokenContract.token1()
+    expect(stakingToken1Address).to.equal(token1Contract.address)
+
+    // sanity check rewards
+    expect(await stakingRewardsContract.rewardsToken())
+      .to.equal(rewardsToken0Contract.address)
+    expect(await stakingRewardsContract.stakingToken())
+      .to.equal(lpTokenContract.address)
+
+    ubeswapSingleRewardFarmBotFactory = await ethers.getContractFactory('RevoUbeswapSingleRewardFarmBot')
+  })
+  it('Able to deploy farm bot to local test chain', async () => {
+    const farmBotContract: RevoUbeswapSingleRewardFarmBot = await ubeswapSingleRewardFarmBotFactory.deploy(
+      deployer.address,
+      reserve.address,
+      stakingRewardsContract.address,
+      lpTokenContract.address,
+      feeContract.address,
+      [rewardsToken0Contract.address],
+      routerContract.address,
+      routerContract.address,
+      'FP'
+    )
+    expect(!!farmBotContract.address).not.to.be.false
+  })
+
+  it('Admin role', async () => {
+    const farmBotContract = (await ubeswapSingleRewardFarmBotFactory.deploy(
+      deployer.address,
+      reserve.address,
+      stakingRewardsContract.address,
+      lpTokenContract.address,
+      feeContract.address,
+      [rewardsToken0Contract.address],
+      routerContract.address,
+      routerContract.address,
+      'FP',
+    ))
+
+    const adminRole = await farmBotContract.DEFAULT_ADMIN_ROLE()
+    expect(await farmBotContract.hasRole(adminRole, deployer.address)).to.be.true
+    expect(await farmBotContract.hasRole(adminRole, compounder.address)).to.be.false
+
+    const compounderRole = await farmBotContract.COMPOUNDER_ROLE()
+    await farmBotContract.grantRole(compounderRole, compounder.address)
+
+    await farmBotContract.connect(deployer).updateFees(feeContract.address)
+    await expect(farmBotContract.connect(investor0).updateFees(feeContract.address)).rejectedWith('AccessControl')
+    await expect(farmBotContract.connect(compounder).updateFees(feeContract.address)).rejectedWith('AccessControl')
+
+    await farmBotContract.connect(deployer).updateReserveAddress(reserve.address)
+    await expect(farmBotContract.connect(investor0).updateReserveAddress(investor0.address)).rejectedWith('AccessControl')
+    await expect(farmBotContract.connect(compounder).updateReserveAddress(reserve.address)).rejectedWith('AccessControl')
+
+
+    await farmBotContract.connect(deployer).updateSlippage(1, 100)
+    await expect(farmBotContract.connect(investor0).updateSlippage(2, 100)).rejectedWith('AccessControl')
+    await expect(farmBotContract.connect(compounder).updateSlippage(1, 100)).rejectedWith('AccessControl')
+  })
+
+  it('Compounder role', async () => {
+    const farmBotContract = (await ubeswapSingleRewardFarmBotFactory.deploy(
+      deployer.address,
+      reserve.address,
+      stakingRewardsContract.address,
+      lpTokenContract.address,
+      feeContract.address,
+      [rewardsToken0Contract.address],
+      routerContract.address,
+      routerContract.address,
+      'FP',
+    ))
+
+    const compounderRole = await farmBotContract.COMPOUNDER_ROLE()
+    expect(await farmBotContract.hasRole(compounderRole, compounder.address)).to.be.false
+
+    const paths: [string[], string[]][] = [
+      [
+        [rewardsToken0Contract.address, stakingToken0Address],
+        [rewardsToken0Contract.address, stakingToken1Address]
+      ]
+    ]
+    const arbitraryDeadline = BigNumber.from(Date.now()).div(1000).add(600)
+    await expect(farmBotContract.connect(compounder).compound(
+      paths,
+      [[0, 0]],
+      arbitraryDeadline,
+    )).to.be.rejectedWith('AccessControl')
+    await farmBotContract.connect(deployer).grantRole(compounderRole, compounder.address)
+    await expect(farmBotContract.connect(compounder).compound(
+      paths,
+      [[0, 0]],
+      arbitraryDeadline,
+    )).not.to.be.rejectedWith('AccessControl')
+  })
+
+  describe('Compound', () => {
+    let farmBotContract: RevoUbeswapSingleRewardFarmBot, paths: [string[], string[]][]
+
+    beforeEach(async () => {
+      farmBotContract = (await ubeswapSingleRewardFarmBotFactory.deploy(
+        deployer.address,
+        reserve.address,
+        stakingRewardsContract.address,
+        lpTokenContract.address,
+        feeContract.address,
+	[rewardsToken0Contract.address],
+        routerContract.address,
+	routerContract.address,
+        'FP',
+      ))
+      paths = [
+	[
+          [rewardsToken0Contract.address, stakingToken0Address],
+          [rewardsToken0Contract.address, stakingToken1Address]
+	]
+      ]
+
+      // load rewards
+      await stakingRewardsContract.setAmountEarned(10)
+      await rewardsToken0Contract.mint(stakingRewardsContract.address, 1000)
+
+      // give compound role
+      const compounderRole = await farmBotContract.COMPOUNDER_ROLE()
+      await farmBotContract.connect(deployer).grantRole(compounderRole, compounder.address)
+
+      // prep router mock
+      await routerContract.setMockLiquidity(10)
+      await routerContract.setMockAmounts([10, 10])
+    })
+
+    it('Single investor earns interest', async () => {
+      await lpTokenContract.mint(investor0.address, 1000)
+      expect(await lpTokenContract.balanceOf(investor0.address)).to.equal(1000)  // sanity check
+
+      // invest
+      await lpTokenContract.connect(investor0).approve(farmBotContract.address, 1000)
+      await farmBotContract.connect(investor0).deposit(1000)
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getFpAmount(1000)).to.equal(1000)
+
+      // compound
+      const arbitraryDeadline = BigNumber.from(Date.now()).div(1000).add(600)
+      await farmBotContract.connect(compounder).compound(
+        paths,
+        [[10, 10]],
+        arbitraryDeadline
+      )
+
+      // check earnings
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getLpAmount(1000)).to.equal(1010)
+    })
+    it('Two investors share interest', async () => {
+      await lpTokenContract.mint(investor0.address, 1000)
+      await lpTokenContract.mint(investor1.address, 1000)
+
+      // investor0 deposit
+      await lpTokenContract.connect(investor0).approve(farmBotContract.address, 1000)
+      await farmBotContract.connect(investor0).deposit(1000)
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.balanceOf(investor1.address)).to.equal(0)
+      expect(await farmBotContract.getFpAmount(1000)).to.equal(1000)
+
+      // investor1 deposit
+      await lpTokenContract.connect(investor1).approve(farmBotContract.address, 1000)
+      await farmBotContract.connect(investor1).deposit(1000)
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.balanceOf(investor1.address)).to.equal(1000)
+
+      // compound
+      const arbitraryDeadline = BigNumber.from(Date.now()).div(1000).add(600)
+      await farmBotContract.connect(compounder).compound(
+        paths,
+        [[10, 10]],
+        arbitraryDeadline
+      )
+
+      // check earnings
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.balanceOf(investor1.address)).to.equal(1000)
+      expect(await farmBotContract.getLpAmount(1000)).to.equal(1005)
+    })
+    it('Early investor earns more', async () => {
+      // investor0 deposit
+      await lpTokenContract.mint(investor0.address, 1000)
+      await lpTokenContract.connect(investor0).approve(farmBotContract.address, 1000)
+      await farmBotContract.connect(investor0).deposit(1000)
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.balanceOf(investor1.address)).to.equal(0)
+      expect(await farmBotContract.getFpAmount(1000)).to.equal(1000)
+
+      // first compound
+      await farmBotContract.connect(compounder).compound(
+        paths,
+        [[10, 10]],
+        BigNumber.from(Date.now()).div(1000).add(600) // arbitrary
+      )
+
+      // check earnings after first compound
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getLpAmount(1000)).to.equal(1010)
+
+      // investor1 deposit
+      await lpTokenContract.mint(investor1.address, 1010)
+      await lpTokenContract.connect(investor1).approve(farmBotContract.address, 1010)
+      await farmBotContract.connect(investor1).deposit(1010)
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.balanceOf(investor1.address)).to.equal(1000)  // since FP:LP ratio was 1010 when investor1 deposited
+
+      // second compound
+      await farmBotContract.connect(compounder).compound(
+        paths,
+        [[10, 10]],
+        BigNumber.from(Date.now()).div(1000).add(600) // arbitrary
+      )
+
+      // check earnings after second compound
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.balanceOf(investor1.address)).to.equal(1000)
+      expect(await farmBotContract.getLpAmount(1000)).to.equal(1015)  // since 10 LPs were split between each investor with 1000 FPs, the value of 1000 FPs rose by 5
+    })
+    it('Works when a swap path is longer than 2', async () => {
+      await lpTokenContract.mint(investor0.address, 1000)
+
+      // invest
+      await lpTokenContract.connect(investor0).approve(farmBotContract.address, 1000)
+      await farmBotContract.connect(investor0).deposit(1000)
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getFpAmount(1000)).to.equal(1000)
+
+      // compound
+      const arbitraryDeadline = BigNumber.from(Date.now()).div(1000).add(600)
+      await farmBotContract.connect(compounder).compound(
+        [
+          [
+            [rewardsToken0Contract.address, stakingToken1Address, stakingToken0Address],
+            [rewardsToken0Contract.address, stakingToken1Address]
+          ]
+        ],
+        [[10, 10]],
+        arbitraryDeadline
+      )
+
+      // check earnings
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getLpAmount(1000)).to.equal(1010)
+    })
+    it('Works when a reward token is also a staking token', async () => {
+      farmBotContract = (await ubeswapSingleRewardFarmBotFactory.deploy(
+        deployer.address,
+        reserve.address,
+        stakingRewardsContract.address,
+        lpTokenContract.address,
+        feeContract.address,
+	[stakingToken0Address],
+        routerContract.address,
+	routerContract.address,
+        'FP',
+      ))
+      const compounderRole = await farmBotContract.COMPOUNDER_ROLE()
+      await farmBotContract.grantRole(compounderRole, compounder.address)
+
+      paths = [
+        [[], [stakingToken0Address, stakingToken1Address]],
+      ]
+
+      await lpTokenContract.mint(investor0.address, 1000)
+
+      // invest
+      await lpTokenContract.connect(investor0).approve(farmBotContract.address, 1000)
+      await farmBotContract.connect(investor0).deposit(1000)
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getFpAmount(1000)).to.equal(1000)
+
+      // compound
+      const arbitraryDeadline = BigNumber.from(Date.now()).div(1000).add(600)
+      await farmBotContract.connect(compounder).compound(
+        paths,
+        [[10, 10]],
+        arbitraryDeadline
+      )
+
+      // check earnings
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getLpAmount(1000)).to.equal(1010)
+    })
+    it('Sends correct fees to reserve, compounder', async () => {
+      await lpTokenContract.mint(investor0.address, 1000)
+      expect(await lpTokenContract.balanceOf(investor0.address)).to.equal(1000)  // sanity check
+
+      // invest
+      await lpTokenContract.connect(investor0).approve(farmBotContract.address, 1000)
+      await farmBotContract.connect(investor0).deposit(1000)
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getFpAmount(1000)).to.equal(1000)
+
+      // set fees
+      await feeContract.connect(deployer).setCompounderFee(1)
+      await feeContract.connect(deployer).setReserveFee(2)
+
+      // set rewards
+      await routerContract.setMockLiquidity(100)
+
+      // compound
+      const arbitraryDeadline = BigNumber.from(Date.now()).div(1000).add(600)
+      await farmBotContract.connect(compounder).compound(
+        paths,
+        [[10, 10]],
+        arbitraryDeadline
+      )
+
+      // check earnings
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getLpAmount(1000)).to.equal(1097)
+
+      // sanity
+      expect(compounder.address).not.to.be.equal(reserve.address)
+
+      // check fees
+      expect(await lpTokenContract.balanceOf(compounder.address)).to.equal(1)
+      expect(await lpTokenContract.balanceOf(reserve.address)).to.equal(2)
+    })
+    it('handles case where one rewards token is depleted', async () => {
+      await stakingRewardsContract.setAmountEarned(0)
+      await lpTokenContract.mint(investor0.address, 1000)
+      await lpTokenContract.connect(investor0).approve(farmBotContract.address, 1000)
+      await farmBotContract.connect(investor0).deposit(1000)
+
+      // compound
+      await farmBotContract.connect(compounder).compound(
+        paths,
+        [[10, 10]],
+        BigNumber.from(Date.now()).div(1000).add(600) // arbitrary
+      )
+
+      // check earnings after first compound
+      expect(await farmBotContract.balanceOf(investor0.address)).to.equal(1000)
+      expect(await farmBotContract.getLpAmount(1000)).to.equal(1010)
+    })
+    it('If rewards tokens left over (due to swap messiness), reinvested next time', async () => {
+      // TODO
+    })
+  })
+})


### PR DESCRIPTION
This is very similar the MoolaStakingRewards implementation; the method names on the staking rewards contracts are actually identical, so this introduces very little new code. Will add explicit tests for this though once my previous test-updating PR is merged.