### PR TITLE
feat(RevoFees): dynamic withdrawal fees, permanent fee contract

### DIFF
--- a/contracts/farms/common/StakingTokenHolder.sol
+++ b/contracts/farms/common/StakingTokenHolder.sol
@@ -34,7 +34,6 @@ import "../../fees/interfaces/IRevoFees.sol";
 abstract contract StakingTokenHolder is ERC20, AccessControl, Pausable {
     using SafeERC20 for IERC20;
 
-    event FeesUpdated(address indexed by, address indexed to);
     event ReserveUpdated(address indexed by, address indexed reserveAddress);
     event SlippageUpdated(
         address indexed by,
@@ -125,14 +124,6 @@ abstract contract StakingTokenHolder is ERC20, AccessControl, Pausable {
         );
         reserveAddress = _reserveAddress;
         emit ReserveUpdated(msg.sender, _reserveAddress);
-    }
-
-    function updateFees(address _revoFees)
-        external
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
-        revoFees = IRevoFees(_revoFees);
-        emit FeesUpdated(msg.sender, _revoFees);
     }
 
     function updateSlippage(

--- a/contracts/fees/RevoFees.sol
+++ b/contracts/fees/RevoFees.sol
@@ -25,6 +25,12 @@ contract RevoFees is Owned, IRevoFees {
         uint256 reserveFeeNumerator,
         uint256 reserveFeeDenominator
     );
+    event WithdrawalFeeUpdated(
+        address indexed by,
+        uint256 withdrawalFeeNumerator,
+        uint256 withdrawalFeeDenominator
+    );
+    event UseDynamicWithdrawalFeesUpdated(address indexed by, bool newValue);
     uint256 public withdrawalFeeNumerator;
     uint256 public withdrawalFeeDenominator;
     bool public useDynamicWithdrawalFees;
@@ -36,7 +42,8 @@ contract RevoFees is Owned, IRevoFees {
         uint256 _reserveFeeNumerator,
         uint256 _reserveFeeDenominator,
         uint256 _withdrawalFeeNumerator,
-        uint256 _withdrawalFeeDenominator
+        uint256 _withdrawalFeeDenominator,
+        bool _useDynamicWithdrawalFees
     ) Owned(_owner) {
         compounderFeeNumerator = _compounderFeeNumerator;
         compounderFeeDenominator = _compounderFeeDenominator;
@@ -44,6 +51,7 @@ contract RevoFees is Owned, IRevoFees {
         reserveFeeDenominator = _reserveFeeDenominator;
         withdrawalFeeNumerator = _withdrawalFeeNumerator;
         withdrawalFeeDenominator = _withdrawalFeeDenominator;
+        useDynamicWithdrawalFees = _useDynamicWithdrawalFees;
     }
 
     function updateCompounderFee(
@@ -78,6 +86,29 @@ contract RevoFees is Owned, IRevoFees {
     ) external onlyOwner {
         withdrawalFeeNumerator = _withdrawalFeeNumerator;
         withdrawalFeeDenominator = _withdrawalFeeDenominator;
+        emit WithdrawalFeeUpdated(
+            msg.sender,
+            _withdrawalFeeNumerator,
+            _withdrawalFeeDenominator
+        );
+    }
+
+    /**
+     * Set a flag for whether dynamic withdrawal fees should be used.
+     *
+     * If true, only rewards earned in the last compounding interval will be counted towards fees.
+     *
+     * Otherwise, static withdrawal fees will be used.
+     */
+    function updateUseDynamicWithdrawalFees(bool _useDynamicWithdrawalFees)
+        external
+        onlyOwner
+    {
+        useDynamicWithdrawalFees = _useDynamicWithdrawalFees;
+        emit UseDynamicWithdrawalFeesUpdated(
+            msg.sender,
+            _useDynamicWithdrawalFees
+        );
     }
 
     /*
@@ -120,20 +151,6 @@ contract RevoFees is Owned, IRevoFees {
      */
     function issueCompounderBonus(address recipient) external pure override {
         return; // intentionally does nothing
-    }
-
-    /**
-     * Set a flag for whether dynamic withdrawal fees should be used.
-     *
-     * If true, only rewards earned in the last compounding interval will be counted towards fees.
-     *
-     * Otherwise, static withdrawal fees will be used.
-     */
-    function setUseDynamicWithdrawalFees(bool _useDynamicWithdrawalFees)
-        external
-        onlyOwner
-    {
-        useDynamicWithdrawalFees = _useDynamicWithdrawalFees;
     }
 
     /*

--- a/contracts/fees/RevoFees.sol
+++ b/contracts/fees/RevoFees.sol
@@ -45,6 +45,12 @@ contract RevoFees is Owned, IRevoFees {
         uint256 _withdrawalFeeDenominator,
         bool _useDynamicWithdrawalFees
     ) Owned(_owner) {
+        require(
+            _compounderFeeDenominator > 0 &&
+                _reserveFeeDenominator > 0 &&
+                _withdrawalFeeDenominator > 0,
+            "Fee denoms must be >0"
+        );
         compounderFeeNumerator = _compounderFeeNumerator;
         compounderFeeDenominator = _compounderFeeDenominator;
         reserveFeeNumerator = _reserveFeeNumerator;
@@ -58,6 +64,7 @@ contract RevoFees is Owned, IRevoFees {
         uint256 _compounderFeeNumerator,
         uint256 _compounderFeeDenominator
     ) external onlyOwner {
+        require(_compounderFeeDenominator > 0, "Denom must be >0");
         compounderFeeNumerator = _compounderFeeNumerator;
         compounderFeeDenominator = _compounderFeeDenominator;
         emit CompounderFeeUpdated(
@@ -71,6 +78,7 @@ contract RevoFees is Owned, IRevoFees {
         uint256 _reserveFeeNumerator,
         uint256 _reserveFeeDenominator
     ) external onlyOwner {
+        require(_reserveFeeDenominator > 0, "Denom must be >0");
         reserveFeeNumerator = _reserveFeeNumerator;
         reserveFeeDenominator = _reserveFeeDenominator;
         emit ReserveFeeUpdated(
@@ -84,6 +92,7 @@ contract RevoFees is Owned, IRevoFees {
         uint256 _withdrawalFeeNumerator,
         uint256 _withdrawalFeeDenominator
     ) external onlyOwner {
+        require(_withdrawalFeeDenominator > 0, "Denom must be >0");
         withdrawalFeeNumerator = _withdrawalFeeNumerator;
         withdrawalFeeDenominator = _withdrawalFeeDenominator;
         emit WithdrawalFeeUpdated(
@@ -174,7 +183,7 @@ contract RevoFees is Owned, IRevoFees {
         override
         returns (uint256 feeNumerator, uint256 feeDenominator)
     {
-        if (useDynamicWithdrawalFees) {
+        if (useDynamicWithdrawalFees && interestEarnedDenominator > 0) {
             feeNumerator = interestEarnedNumerator;
             feeDenominator = interestEarnedDenominator;
         } else {

--- a/contracts/fees/RevoFees.sol
+++ b/contracts/fees/RevoFees.sol
@@ -125,12 +125,13 @@ contract RevoFees is Owned, IRevoFees {
     /**
      * Set a flag for whether dynamic withdrawal fees should be used.
      *
-     * If true, only rewards earned in the last compounding interval will be counted towards fees.@author
+     * If true, only rewards earned in the last compounding interval will be counted towards fees.
      *
      * Otherwise, static withdrawal fees will be used.
      */
     function setUseDynamicWithdrawalFees(bool _useDynamicWithdrawalFees)
         external
+        onlyOwner
     {
         useDynamicWithdrawalFees = _useDynamicWithdrawalFees;
     }
@@ -142,8 +143,7 @@ contract RevoFees is Owned, IRevoFees {
      *   right after and taking some of the rewards. (Withdrawal fee should be >= the interest gained from the last time
      *   'compound' was called.)
      *
-     * Takes the interest earned the last time 'compound' was called as a parameter. This makes it possible to have dynamic
-     *   withdrawal fees.
+     * If useDynamicWithdrawalFees is true, sets the fee to interest earned in the last compounding interval.
      *
      * (Note that there is a maximum fee set in the Farm Bot contract to protect
      *   users from unreasonably high withdrawal fees.)
@@ -151,12 +151,13 @@ contract RevoFees is Owned, IRevoFees {
     function withdrawalFee(
         uint256 interestEarnedNumerator,
         uint256 interestEarnedDenominator
-    ) external override returns (uint256 feeNumerator, uint256 feeDenominator) {
-        if (
-            useDynamicWithdrawalFees &&
-            interestEarnedNumerator * withdrawalFeeDenominator <
-            withdrawalFeeNumerator * interestEarnedDenominator
-        ) {
+    )
+        external
+        view
+        override
+        returns (uint256 feeNumerator, uint256 feeDenominator)
+    {
+        if (useDynamicWithdrawalFees) {
             feeNumerator = interestEarnedNumerator;
             feeDenominator = interestEarnedDenominator;
         } else {

--- a/test/RevoUbeswapSingleRewardFarmBot.test.ts
+++ b/test/RevoUbeswapSingleRewardFarmBot.test.ts
@@ -107,10 +107,6 @@ describe('RevoUbeswapSingleRewardFarmBot tests', () => {
     const compounderRole = await farmBotContract.COMPOUNDER_ROLE()
     await farmBotContract.grantRole(compounderRole, compounder.address)
 
-    await farmBotContract.connect(deployer).updateFees(feeContract.address)
-    await expect(farmBotContract.connect(investor0).updateFees(feeContract.address)).rejectedWith('AccessControl')
-    await expect(farmBotContract.connect(compounder).updateFees(feeContract.address)).rejectedWith('AccessControl')
-
     await farmBotContract.connect(deployer).updateReserveAddress(reserve.address)
     await expect(farmBotContract.connect(investor0).updateReserveAddress(investor0.address)).rejectedWith('AccessControl')
     await expect(farmBotContract.connect(compounder).updateReserveAddress(reserve.address)).rejectedWith('AccessControl')

--- a/test/farm-bot-test.ts
+++ b/test/farm-bot-test.ts
@@ -109,10 +109,6 @@ describe('Farm bot tests', () => {
     const compounderRole = await farmBotContract.COMPOUNDER_ROLE()
     await farmBotContract.grantRole(compounderRole, compounder.address)
 
-    await farmBotContract.connect(deployer).updateFees(feeContract.address)
-    await expect(farmBotContract.connect(investor0).updateFees(feeContract.address)).rejectedWith('AccessControl')
-    await expect(farmBotContract.connect(compounder).updateFees(feeContract.address)).rejectedWith('AccessControl')
-
     await farmBotContract.connect(deployer).updateReserveAddress(reserve.address)
     await expect(farmBotContract.connect(investor0).updateReserveAddress(investor0.address)).rejectedWith('AccessControl')
     await expect(farmBotContract.connect(compounder).updateReserveAddress(reserve.address)).rejectedWith('AccessControl')

--- a/test/revo-fees-test.ts
+++ b/test/revo-fees-test.ts
@@ -56,5 +56,42 @@ describe('Unit tests for RevoFees contract', async () => {
     expect(await feeContract.withdrawalFeeNumerator()).to.equal(4)
     expect(await feeContract.withdrawalFeeDenominator()).to.equal(100)
   })
+  it('Cannot set fee denominators to 0', async () => {
+    await expect(feeContract.connect(owner).updateCompounderFee(2, 0)).rejectedWith('>0')
+    await expect(feeContract.connect(owner).updateReserveFee(3,0)).rejectedWith('>0')
+    await expect(feeContract.connect(owner).updateWithdrawalFee(4,0)).rejectedWith('>0')
+
+    const contractFactory = await ethers.getContractFactory('RevoFees')
+    await expect(contractFactory.deploy(
+      await owner.getAddress(),  // owner
+      1, // compounderFeeNumerator
+      0, // compounderFeeDenominator (shouldnt be 0)
+      1, // reserveFeeNumerator
+      1, // reserveFeeDenominator
+      1, // withdrawalFeeNumerator
+      1, // withdrawalFeeDenominator
+      false // useDynamicWithdrawalFees
+    )).rejectedWith(">0")
+    await expect(contractFactory.deploy(
+      await owner.getAddress(),  // owner
+      1, // compounderFeeNumerator
+      1, // compounderFeeDenominator
+      1, // reserveFeeNumerator
+      0, // reserveFeeDenominator (shouldn't be 0)
+      1, // withdrawalFeeNumerator
+      1, // withdrawalFeeDenominator
+      false // useDynamicWithdrawalFees
+    )).rejectedWith(">0")
+    await expect(contractFactory.deploy(
+      await owner.getAddress(),  // owner
+      1, // compounderFeeNumerator
+      1, // compounderFeeDenominator
+      1, // reserveFeeNumerator
+      1, // reserveFeeDenominator
+      1, // withdrawalFeeNumerator
+      0, // withdrawalFeeDenominator (shouldn't be 0)
+      false // useDynamicWithdrawalFees
+    )).rejectedWith(">0")
+  })
 })
 

--- a/test/revo-fees-test.ts
+++ b/test/revo-fees-test.ts
@@ -1,19 +1,29 @@
 import {expect} from 'chai'
+import * as chai from 'chai'
+import chaiAsPromised = require("chai-as-promised")
+chai.use(chaiAsPromised)
 import {RevoFees} from "../typechain"
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
 
 const {ethers} = require('hardhat')
 
 describe('Unit tests for RevoFees contract', async () => {
-  it('fees can be accessed', async () => {
-    const [owner] = await ethers.getSigners()
+  let feeContract: RevoFees, owner: SignerWithAddress, nonOwner: SignerWithAddress
+  beforeEach(async () => {
+    [owner, nonOwner] = (await ethers.getSigners())
     const contractFactory = await ethers.getContractFactory('RevoFees')
-    const feeContract: RevoFees = await contractFactory.deploy(
+    feeContract = await contractFactory.deploy(
       await owner.getAddress(),  // owner
       1, // compounderFeeNumerator
       1000, // compounderFeeDenominator
       2, // reserveFeeNumerator
-      1001 // reserveFeeDenominator
+      1001, // reserveFeeDenominator
+      25, // withdrawalFeeNumerator
+      10000, // withdrawalFeeDenominator
+      false // useDynamicWithdrawalFees
     )
+  })
+  it('fees can be accessed', async () => {
     expect(await feeContract.compounderFeeNumerator()).to.equal(1)
     expect(await feeContract.compounderFeeDenominator()).to.equal(1000)
     expect(await feeContract.reserveFeeNumerator()).to.equal(2)
@@ -21,6 +31,30 @@ describe('Unit tests for RevoFees contract', async () => {
     const {feeNumerator: withdrawalFeeNumerator, feeDenominator: withdrawalFeeDenominator} = await feeContract.withdrawalFee(1, 1000)
     expect(withdrawalFeeNumerator).to.equal(25)
     expect(withdrawalFeeDenominator).to.equal(10000)
+  })
+  it('useDynamicWithdrawalFee: enables dynamic withdrawal fees', async () => {
+    await feeContract.connect(owner).updateUseDynamicWithdrawalFees(true)
+    const {feeNumerator: dynamicWithdrawalFeeNumerator, feeDenominator: dynamicWithdrawalFeeDenominator} = await feeContract.withdrawalFee(1, 1000)
+    expect(dynamicWithdrawalFeeNumerator).to.equal(1)
+    expect(dynamicWithdrawalFeeDenominator).to.equal(1000)
+  })
+  it('setters can only be used by owner', async () => {
+    await expect(feeContract.connect(nonOwner).updateUseDynamicWithdrawalFees(true)).rejectedWith('contract owner')
+    await expect(feeContract.connect(nonOwner).updateCompounderFee(2, 100)).rejectedWith('contract owner')
+    await expect(feeContract.connect(nonOwner).updateReserveFee(3,100)).rejectedWith('contract owner')
+    await expect(feeContract.connect(nonOwner).updateWithdrawalFee(4,100)).rejectedWith('contract owner')
+
+    await feeContract.connect(owner).updateUseDynamicWithdrawalFees(true)
+    expect(await feeContract.useDynamicWithdrawalFees()).to.be.true
+    await feeContract.connect(owner).updateCompounderFee(2, 100)
+    expect(await feeContract.compounderFeeNumerator()).to.equal(2)
+    expect(await feeContract.compounderFeeDenominator()).to.equal(100)
+    await feeContract.connect(owner).updateReserveFee(3,100)
+    expect(await feeContract.reserveFeeNumerator()).to.equal(3)
+    expect(await feeContract.reserveFeeDenominator()).to.equal(100)
+    await feeContract.connect(owner).updateWithdrawalFee(4,100)
+    expect(await feeContract.withdrawalFeeNumerator()).to.equal(4)
+    expect(await feeContract.withdrawalFeeDenominator()).to.equal(100)
   })
 })
 


### PR DESCRIPTION
- Added dynamic withdrawal fees
- settable fixed withdrawal fees
- feature flag so we can revert back to fixed withdrawal fees
- removed ability to set an entirely new fees contract on farm bots (since that could be mis-used to stop withdrawals)